### PR TITLE
Interactive UX overhaul

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ import re
 from collections import defaultdict
 from pathlib import Path
 
-from flask import Flask, jsonify, render_template
+from flask import Flask, jsonify, render_template, abort
 import markdown
 
 app = Flask(__name__)
@@ -28,18 +28,24 @@ CATEGORY_MAP = {
 }
 
 SLUG_LABELS = {
-    "world": "World Overview",
-    "europe": "Europe",
-    "mideast": "Middle East",
-    "africa": "Africa",
-    "asia": "Asia-Pacific",
-    "americas": "Americas",
-    "state-media": "State Media Watch",
-    "tech": "Tech Overview",
-    "tech-ai": "AI & ML",
-    "tech-security": "Cybersecurity",
-    "tech-crypto": "Crypto & Blockchain",
+    "world": "🌍 World",
+    "europe": "📰 Europe",
+    "mideast": "📰 Mideast",
+    "africa": "📰 Africa",
+    "asia": "📰 Asia-Pacific",
+    "americas": "📰 Americas",
+    "state-media": "📰 State Media",
+    "tech": "💻 Tech",
+    "tech-ai": "💻 AI",
+    "tech-security": "💻 Security",
+    "tech-crypto": "💻 Crypto",
 }
+
+# Canonical order for tab display
+SLUG_ORDER = [
+    "world", "europe", "mideast", "africa", "asia", "americas",
+    "state-media", "tech", "tech-ai", "tech-security", "tech-crypto",
+]
 
 COORDS = {
     "norway": (59.9, 10.7), "sweden": (59.3, 18.1), "finland": (60.2, 24.9),
@@ -61,7 +67,6 @@ COORDS = {
     "switzerland": (46.9, 7.4), "oman": (23.6, 58.5),
 }
 
-# Aliases that map to a COORDS key
 LOCATION_ALIASES = {
     "united states": "usa", "u.s.": "usa", "america": "usa", "washington": "usa",
     "american": "usa", "pentagon": "usa", "white house": "usa",
@@ -72,7 +77,7 @@ LOCATION_ALIASES = {
     "moscow": "russia", "russian": "russia", "kremlin": "russia",
     "beijing": "china", "chinese": "china",
     "tokyo": "japan", "japanese": "japan",
-    "iranian": "iran", "tehran": "iran", "tehran": "iran",
+    "iranian": "iran", "tehran": "iran",
     "israeli": "israel", "tel aviv": "israel", "jerusalem": "israel", "netanyahu": "israel",
     "palestinian": "palestine", "west bank": "palestine",
     "turkish": "turkey", "ankara": "turkey", "istanbul": "turkey",
@@ -110,13 +115,11 @@ LOCATION_ALIASES = {
     "arabian sea": "oman",
 }
 
-# Build a sorted (longest-first) pattern list for matching
 _all_locations = {}
 for k in COORDS:
     _all_locations[k] = k
 for alias, key in LOCATION_ALIASES.items():
     _all_locations[alias] = key
-# Sort by length descending so "south korea" matches before "south" or "korea"
 _LOCATION_PATTERNS = sorted(_all_locations.keys(), key=len, reverse=True)
 _LOCATION_RE = re.compile(
     r'\b(' + '|'.join(re.escape(p) for p in _LOCATION_PATTERNS) + r')(?:\b|(?=\s|[,.\-:;\'"!\?]))',
@@ -144,8 +147,32 @@ def render_md(text):
     return html
 
 
+def render_log_md(text):
+    """Render log markdown - make all URLs clickable even if not in markdown link format."""
+    # First do normal markdown render
+    html = markdown.markdown(
+        text,
+        extensions=["tables", "fenced_code", "nl2br"],
+    )
+    html = html.replace("<a ", '<a target="_blank" rel="noopener" ')
+    # Make bare URLs clickable (not already in href)
+    html = re.sub(
+        r'(?<!href=")(?<!">)(https?://[^\s<>"]+)',
+        r'<a href="\1" target="_blank" rel="noopener">\1</a>',
+        html
+    )
+    return html
+
+
+def word_count(text):
+    return len(re.findall(r'\w+', text))
+
+
+def reading_time_minutes(text):
+    return max(1, round(word_count(text) / 230))
+
+
 def extract_headline(text):
-    """Get the first H1 or H2 or first non-empty line."""
     for line in text.splitlines():
         line = line.strip()
         if line.startswith("# "):
@@ -159,8 +186,15 @@ def extract_headline(text):
     return "Report"
 
 
+def extract_headings(html):
+    """Extract h2 headings for TOC generation (done client-side, but we pass raw text headings)."""
+    headings = []
+    for m in re.finditer(r'^##\s+(.+)$', html, re.MULTILINE):
+        headings.append(m.group(1).strip())
+    return headings
+
+
 def detect_trust(text):
-    """Dominant trust rating in a paragraph."""
     high = len(re.findall(r"🟢\s*HIGH", text))
     med = len(re.findall(r"🟡\s*MED", text))
     state = len(re.findall(r"🔴\s*STATE", text))
@@ -171,24 +205,31 @@ def detect_trust(text):
     return "high"
 
 
-def extract_geo_markers(text, slug, label):
-    """Extract geo markers from report text. Returns list of {lat,lng,trust,headline,label,country}."""
-    headline = extract_headline(text)
+def extract_countries_from_text(text):
+    """Return list of unique country keys mentioned in text."""
+    found = _LOCATION_RE.findall(text)
+    seen = []
+    seen_keys = set()
+    for loc_match in found:
+        key = _all_locations.get(loc_match.lower())
+        if key and key not in seen_keys:
+            seen_keys.add(key)
+            seen.append(key)
+    return seen
 
-    # Split into sections by H2
+
+def extract_geo_markers(text, slug, label):
+    headline = extract_headline(text)
     sections = re.split(r'\n(?=## )', text)
     markers = []
-    seen_locations = set()  # per-report dedup by country key
+    seen_locations = set()
 
     for section in sections:
         section_headline = headline
         first_line = section.strip().split('\n')[0].strip()
         if first_line.startswith("## "):
             section_headline = first_line.lstrip("# ").strip()
-
         trust = detect_trust(section)
-
-        # Find all location mentions
         found = _LOCATION_RE.findall(section)
         for loc_match in found:
             key = _all_locations.get(loc_match.lower())
@@ -197,60 +238,30 @@ def extract_geo_markers(text, slug, label):
             seen_locations.add(key)
             lat, lng = COORDS[key]
             markers.append({
-                "lat": lat,
-                "lng": lng,
-                "trust": trust,
+                "lat": lat, "lng": lng, "trust": trust,
                 "headline": section_headline[:150],
-                "label": label,
-                "country": key.title(),
+                "label": label, "country": key.title(),
+                "countryKey": key,
             })
-
     return markers
 
 
-@app.route("/api/map-data")
-def api_map_data():
-    """Return all geo markers from the most recent date's reports."""
-    # Find most recent date
-    dates = set()
-    if REPORTS_DIR.exists():
-        for f in REPORTS_DIR.iterdir():
-            parsed = parse_filename(f.name)
-            if parsed:
-                dates.add(parsed[0])
-    if not dates:
-        return jsonify([])
-    date = max(dates)
-
-    # Collect markers, group by country
-    country_data = defaultdict(lambda: {"headlines": [], "trust": "high"})
-    if REPORTS_DIR.exists():
-        for f in sorted(REPORTS_DIR.iterdir()):
-            parsed = parse_filename(f.name)
-            if not parsed or parsed[0] != date:
-                continue
-            slug = parsed[1]
-            label = SLUG_LABELS.get(slug, slug.replace("-", " ").title())
-            content = f.read_text(encoding="utf-8")
-            markers = extract_geo_markers(content, slug, label)
-            for m in markers:
-                key = m["country"]
-                country_data[key]["lat"] = m["lat"]
-                country_data[key]["lng"] = m["lng"]
-                country_data[key]["country"] = key
-                country_data[key]["headlines"].append({
-                    "title": m["headline"],
-                    "section": m["label"],
-                    "trust": m["trust"],
-                })
-                # Worst trust wins
-                cur = country_data[key]["trust"]
-                if m["trust"] == "state" or cur == "state":
-                    country_data[key]["trust"] = "state"
-                elif m["trust"] == "med" or cur == "med":
-                    country_data[key]["trust"] = "med"
-
-    return jsonify(list(country_data.values()))
+def parse_source_diversity(text):
+    """Parse source diversity from log files for visualization."""
+    scores = {}
+    in_diversity = False
+    for line in text.splitlines():
+        if 'source diversity' in line.lower() or 'source balance' in line.lower():
+            in_diversity = True
+            continue
+        if in_diversity:
+            m = re.match(r'[-*]\s*\*?\*?(.+?)\*?\*?\s*:\s*(\d+)', line.strip())
+            if m:
+                scores[m.group(1).strip()] = int(m.group(2))
+            elif line.strip() == '' or line.startswith('#'):
+                if scores:
+                    break
+    return scores
 
 
 @app.route("/")
@@ -264,7 +275,7 @@ def api_dates():
     if REPORTS_DIR.exists():
         for f in REPORTS_DIR.iterdir():
             parsed = parse_filename(f.name)
-            if parsed:
+            if parsed and not f.name.endswith("-log.md"):
                 dates.add(parsed[0])
     return jsonify(sorted(dates, reverse=True))
 
@@ -274,37 +285,106 @@ def api_reports(date):
     if not re.match(r"^\d{4}-\d{2}-\d{2}$", date):
         return jsonify({"error": "bad date"}), 400
 
-    groups = defaultdict(list)
+    reports_list = []
     all_markers = []
 
     if REPORTS_DIR.exists():
         for f in sorted(REPORTS_DIR.iterdir()):
             parsed = parse_filename(f.name)
-            if not parsed or parsed[0] != date:
+            if not parsed or parsed[0] != date or f.name.endswith("-log.md"):
                 continue
             slug = parsed[1]
-            cat, order = CATEGORY_MAP.get(slug, ("📰 Regional", 1))
             content = f.read_text(encoding="utf-8")
             html = render_md(content)
             label = SLUG_LABELS.get(slug, slug.replace("-", " ").title())
-            groups[cat].append({"slug": slug, "label": label, "html": html, "order": order})
+            countries = extract_countries_from_text(content)
+            headings = extract_headings(content)
+            read_time = reading_time_minutes(content)
+
+            # Check if log file exists
+            log_file = REPORTS_DIR / f"{date}-{slug}-log.md"
+            has_log = log_file.exists()
+
+            reports_list.append({
+                "slug": slug,
+                "label": label,
+                "html": html,
+                "countries": countries,
+                "headings": headings,
+                "readTime": read_time,
+                "hasLog": has_log,
+            })
 
             markers = extract_geo_markers(content, slug, label)
             all_markers.extend(markers)
 
-    result = []
-    seen = set()
-    for cat in sorted(groups.keys(), key=lambda c: groups[c][0]["order"]):
-        if cat in seen:
-            continue
-        seen.add(cat)
-        items = sorted(groups[cat], key=lambda x: x["slug"])
-        result.append({
-            "category": cat,
-            "reports": [{"slug": r["slug"], "label": r["label"], "html": r["html"]} for r in items],
-        })
+    # Sort by canonical order
+    slug_order_map = {s: i for i, s in enumerate(SLUG_ORDER)}
+    reports_list.sort(key=lambda r: slug_order_map.get(r["slug"], 99))
 
-    return jsonify({"groups": result, "markers": all_markers})
+    return jsonify({"reports": reports_list, "markers": all_markers})
+
+
+@app.route("/api/map-data")
+def api_map_data():
+    dates = set()
+    if REPORTS_DIR.exists():
+        for f in REPORTS_DIR.iterdir():
+            parsed = parse_filename(f.name)
+            if parsed and not f.name.endswith("-log.md"):
+                dates.add(parsed[0])
+    if not dates:
+        return jsonify([])
+    date = max(dates)
+
+    country_data = defaultdict(lambda: {"headlines": [], "trust": "high"})
+    if REPORTS_DIR.exists():
+        for f in sorted(REPORTS_DIR.iterdir()):
+            parsed = parse_filename(f.name)
+            if not parsed or parsed[0] != date or f.name.endswith("-log.md"):
+                continue
+            slug = parsed[1]
+            label = SLUG_LABELS.get(slug, slug.replace("-", " ").title())
+            content = f.read_text(encoding="utf-8")
+            markers = extract_geo_markers(content, slug, label)
+            for m in markers:
+                key = m["country"]
+                country_data[key]["lat"] = m["lat"]
+                country_data[key]["lng"] = m["lng"]
+                country_data[key]["country"] = key
+                country_data[key]["countryKey"] = m["countryKey"]
+                country_data[key]["headlines"].append({
+                    "title": m["headline"],
+                    "section": m["label"],
+                    "trust": m["trust"],
+                })
+                cur = country_data[key]["trust"]
+                if m["trust"] == "state" or cur == "state":
+                    country_data[key]["trust"] = "state"
+                elif m["trust"] == "med" or cur == "med":
+                    country_data[key]["trust"] = "med"
+
+    return jsonify(list(country_data.values()))
+
+
+@app.route("/report/<date>/<slug>/log")
+def report_log(date, slug):
+    if not re.match(r"^\d{4}-\d{2}-\d{2}$", date):
+        abort(400)
+    log_file = REPORTS_DIR / f"{date}-{slug}-log.md"
+    if not log_file.exists():
+        abort(404)
+    content = log_file.read_text(encoding="utf-8")
+    html = render_log_md(content)
+    label = SLUG_LABELS.get(slug, slug.replace("-", " ").title())
+    diversity = parse_source_diversity(content)
+    return render_template("log.html", html=html, date=date, slug=slug, label=label, diversity=diversity)
+
+
+@app.route("/api/coords")
+def api_coords():
+    """Return all known coordinates for client-side map panning."""
+    return jsonify({k: {"lat": v[0], "lng": v[1]} for k, v in COORDS.items()})
 
 
 if __name__ == "__main__":

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Newsroom — Intelligence Dashboard</title>
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
-<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" />
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 :root{
@@ -17,43 +17,33 @@
   --serif:'Georgia','Times New Roman',serif;
   --mono:'SF Mono','Cascadia Code','Consolas',monospace;
   --sans:-apple-system,'Segoe UI','Helvetica Neue',sans-serif;
-  --sidebar-w:260px;
 }
-html{font-size:16px;-webkit-font-smoothing:antialiased}
-body{background:var(--bg);color:var(--fg);font-family:var(--serif);line-height:1.7;display:flex;min-height:100vh}
+html{font-size:16px;-webkit-font-smoothing:antialiased;scroll-behavior:smooth}
+body{background:var(--bg);color:var(--fg);font-family:var(--serif);line-height:1.7;min-height:100vh}
 
-/* Sidebar */
-.sidebar{
-  width:var(--sidebar-w);min-width:var(--sidebar-w);background:var(--bg2);
-  border-right:1px solid var(--border);display:flex;flex-direction:column;
-  position:fixed;top:0;left:0;bottom:0;z-index:10;transition:transform .2s ease;
+/* Progress bar */
+#progressBar{
+  position:fixed;top:0;left:0;height:3px;background:var(--accent);
+  z-index:100;transition:width 80ms linear;width:0;
 }
-.sidebar-header{
-  padding:1.25rem 1rem .75rem;border-bottom:1px solid var(--border);
-  font-family:var(--mono);font-size:.75rem;letter-spacing:.08em;
-  text-transform:uppercase;color:var(--fg3);
-}
-.sidebar-header h1{font-size:1rem;letter-spacing:.12em;color:var(--fg);margin-bottom:.15rem;text-transform:uppercase}
-.date-list{flex:1;overflow-y:auto;padding:.5rem 0}
-.date-item{
-  display:block;width:100%;text-align:left;background:none;border:none;
-  padding:.55rem 1rem;font-family:var(--mono);font-size:.85rem;
-  color:var(--fg2);cursor:pointer;transition:all .1s;
-}
-.date-item:hover{background:var(--bg3);color:var(--fg)}
-.date-item.active{background:var(--bg4);color:var(--accent2);border-left:2px solid var(--accent)}
 
-/* Main */
-.main{margin-left:var(--sidebar-w);flex:1;min-width:0}
-.topbar{
-  position:sticky;top:0;z-index:5;background:var(--bg);
-  border-bottom:1px solid var(--border);padding:.6rem 2rem;
-  font-family:var(--mono);font-size:.8rem;color:var(--fg3);
-  display:flex;align-items:center;gap:1rem;
-  backdrop-filter:blur(8px);
+/* Header */
+.header{
+  position:sticky;top:0;z-index:50;background:var(--bg);
+  border-bottom:1px solid var(--border);
+  backdrop-filter:blur(12px);
 }
-.hamburger{display:none;background:none;border:none;color:var(--fg);font-size:1.3rem;cursor:pointer;padding:.2rem .5rem}
-.topbar-spacer{flex:1}
+.header-top{
+  display:flex;align-items:center;gap:1rem;padding:.5rem 1.5rem;
+}
+.logo{font-family:var(--mono);font-size:1rem;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--fg)}
+.date-picker{
+  font-family:var(--mono);font-size:.8rem;background:var(--bg3);
+  border:1px solid var(--border);color:var(--fg);padding:.3rem .6rem;
+  border-radius:4px;cursor:pointer;
+}
+.date-picker option{background:var(--bg2);color:var(--fg)}
+.header-spacer{flex:1}
 .map-toggle{
   background:var(--bg3);border:1px solid var(--border);color:var(--fg2);
   font-family:var(--mono);font-size:.75rem;padding:.3rem .7rem;border-radius:4px;
@@ -61,40 +51,107 @@ body{background:var(--bg);color:var(--fg);font-family:var(--serif);line-height:1
 }
 .map-toggle:hover{background:var(--bg4);color:var(--fg)}
 .map-toggle.active{background:rgba(59,130,246,.15);color:var(--accent2);border-color:var(--accent)}
+.map-count{
+  display:inline-block;background:var(--bg4);color:var(--fg2);
+  font-family:var(--mono);font-size:.65rem;padding:.1rem .35rem;
+  border-radius:3px;margin-left:.4rem;
+}
+.kbd-hint{font-family:var(--mono);font-size:.6rem;color:var(--fg3);margin-left:.3rem}
+.hamburger{display:none;background:none;border:none;color:var(--fg);font-size:1.3rem;cursor:pointer;padding:.2rem .5rem}
+
+/* Tabs */
+.tab-bar{
+  display:flex;gap:0;padding:0 1.5rem;overflow-x:auto;
+  scrollbar-width:none;-ms-overflow-style:none;
+}
+.tab-bar::-webkit-scrollbar{display:none}
+.tab{
+  flex-shrink:0;padding:.45rem .9rem;font-family:var(--mono);font-size:.72rem;
+  letter-spacing:.04em;color:var(--fg3);cursor:pointer;
+  border:none;background:none;border-bottom:2px solid transparent;
+  transition:all .15s;white-space:nowrap;
+}
+.tab:hover{color:var(--fg2);background:var(--bg3)}
+.tab.active{color:var(--accent2);border-bottom-color:var(--accent)}
 
 /* Map */
-.map-panel{
-  height:0;overflow:hidden;transition:height .3s ease;
-  border-bottom:1px solid var(--border);position:relative;
-}
-.map-panel.open{height:420px}
+.map-panel{height:0;overflow:hidden;transition:height .3s ease;border-bottom:1px solid var(--border)}
+.map-panel.open{height:400px}
 #map{width:100%;height:100%;background:var(--bg2)}
-/* Dark map tiles */
 .leaflet-tile-pane{filter:brightness(0.7) invert(1) contrast(1.1) hue-rotate(200deg) saturate(0.4) brightness(0.8)}
 .leaflet-control-attribution{display:none!important}
 .leaflet-control-zoom a{background:var(--bg3)!important;color:var(--fg)!important;border-color:var(--border)!important}
 
-.content{max-width:52rem;margin:0 auto;padding:1.5rem 2rem 4rem}
+/* Layout: content + TOC */
+.layout{display:flex;max-width:72rem;margin:0 auto;padding:0 1.5rem}
+.content-col{flex:1;min-width:0;padding:1.5rem 0 4rem}
+.toc-col{
+  width:220px;flex-shrink:0;position:sticky;top:80px;
+  align-self:flex-start;max-height:calc(100vh - 100px);overflow-y:auto;
+  padding:1.5rem 0 1.5rem 1.5rem;
+  scrollbar-width:thin;
+}
+.toc-title{font-family:var(--mono);font-size:.65rem;letter-spacing:.1em;text-transform:uppercase;color:var(--fg3);margin-bottom:.5rem}
+.toc-link{
+  display:block;font-family:var(--mono);font-size:.7rem;color:var(--fg3);
+  text-decoration:none;padding:.2rem 0 .2rem .5rem;
+  border-left:2px solid var(--border);transition:all .1s;
+  white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+}
+.toc-link:hover{color:var(--fg2);border-left-color:var(--fg3)}
+.toc-link.active{color:var(--accent2);border-left-color:var(--accent)}
+
 .empty{text-align:center;padding:6rem 2rem;color:var(--fg3);font-family:var(--mono);font-size:.9rem}
 
-/* Categories & reports */
-.category{margin-bottom:2.5rem}
-.category-header{
-  font-family:var(--mono);font-size:.8rem;letter-spacing:.1em;
-  text-transform:uppercase;color:var(--fg3);
-  padding-bottom:.4rem;border-bottom:1px solid var(--border);margin-bottom:1rem;
+/* Report meta bar */
+.report-meta{
+  display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;
+  margin-bottom:1rem;padding-bottom:.75rem;border-bottom:1px solid var(--border);
 }
-.report{margin-bottom:2rem;padding-bottom:1.5rem;border-bottom:1px solid var(--border)}
-.report:last-child{border-bottom:none}
+.read-time{font-family:var(--mono);font-size:.7rem;color:var(--fg3)}
+.log-btn{
+  font-family:var(--mono);font-size:.7rem;color:var(--accent2);
+  text-decoration:none;background:rgba(59,130,246,.08);
+  padding:.2rem .5rem;border-radius:3px;transition:all .15s;
+}
+.log-btn:hover{background:rgba(59,130,246,.18)}
+
+/* Country tags */
+.country-tag{
+  display:inline-block;font-family:var(--mono);font-size:.6rem;
+  background:var(--bg3);color:var(--fg2);padding:.1rem .4rem;
+  border-radius:3px;cursor:pointer;transition:all .15s;
+  margin:0 .15rem;vertical-align:middle;
+}
+.country-tag:hover{background:var(--accent);color:#fff}
+.country-tag.highlighted{background:var(--accent);color:#fff;animation:pulse .6s ease}
+@keyframes pulse{0%,100%{transform:scale(1)}50%{transform:scale(1.1)}}
+
+/* Report sections */
+.report{margin-bottom:2rem}
 .report-label{
   font-family:var(--mono);font-size:.7rem;letter-spacing:.08em;
   text-transform:uppercase;color:var(--accent);margin-bottom:.75rem;
   display:inline-block;background:rgba(59,130,246,.1);padding:.15rem .5rem;border-radius:3px;
 }
 
-/* Markdown */
+/* Collapsible sections */
+.section-header{
+  display:flex;align-items:center;cursor:pointer;user-select:none;
+  padding:.3rem 0;margin:1.4rem 0 .5rem;
+}
+.section-header:hover{opacity:.85}
+.section-chevron{
+  font-size:.7rem;color:var(--fg3);margin-right:.5rem;
+  transition:transform .2s;flex-shrink:0;
+}
+.section-header.collapsed .section-chevron{transform:rotate(-90deg)}
+.section-body{overflow:hidden;transition:max-height .3s ease}
+.section-body.collapsed{max-height:0!important;overflow:hidden}
+
+/* Markdown styles */
 .report h1{font-family:var(--mono);font-size:1.35rem;color:var(--fg);margin:1.2rem 0 .6rem;line-height:1.3;font-weight:600}
-.report h2{font-family:var(--mono);font-size:1.05rem;color:var(--fg);margin:1.4rem 0 .5rem;line-height:1.35;font-weight:600}
+.report h2{font-family:var(--mono);font-size:1.05rem;color:var(--fg);line-height:1.35;font-weight:600;margin:0}
 .report h3{font-family:var(--mono);font-size:.9rem;color:var(--fg2);margin:1rem 0 .4rem;font-weight:600}
 .report h4,.report h5,.report h6{font-family:var(--mono);font-size:.8rem;color:var(--fg2);margin:.8rem 0 .3rem;font-weight:600}
 .report p{margin:.5rem 0;color:var(--fg)}
@@ -103,23 +160,26 @@ body{background:var(--bg);color:var(--fg);font-family:var(--serif);line-height:1
 .report strong{color:#e4e4e7;font-weight:600}
 .report em{color:var(--fg2);font-style:italic}
 .report blockquote{
-  border-left:3px solid var(--accent);margin:.8rem 0;padding:.3rem .8rem .3rem 1rem;
+  border-left:3px solid var(--accent);margin:.8rem 0;padding:.5rem 1rem;
   color:var(--fg2);background:var(--bg2);border-radius:0 4px 4px 0;
+  font-style:italic;opacity:.85;
 }
 .report hr{border:none;border-top:1px solid var(--border);margin:1.5rem 0}
-.report a{color:var(--accent2);text-decoration:underline;text-underline-offset:2px;transition:color .1s}
-.report a:hover{color:#93c5fd}
+.report a{color:var(--accent2);text-decoration:none;border-bottom:1px solid transparent;transition:all .15s}
+.report a:hover{color:#93c5fd;border-bottom-color:var(--accent2)}
 .report code{font-family:var(--mono);font-size:.85em;background:var(--bg3);padding:.1em .35em;border-radius:3px;color:#e4e4e7}
 .report pre{background:var(--bg2);border:1px solid var(--border);border-radius:4px;padding:.8rem 1rem;overflow-x:auto;margin:.8rem 0}
 .report pre code{background:none;padding:0}
-.report table{width:100%;border-collapse:collapse;margin:.8rem 0;font-size:.9rem}
-.report th,.report td{padding:.4rem .6rem;border:1px solid var(--border);text-align:left}
-.report th{background:var(--bg3);font-family:var(--mono);font-size:.8rem;font-weight:600}
+.report table{width:100%;border-collapse:collapse;margin:.8rem 0;font-size:.88rem}
+.report th,.report td{padding:.45rem .6rem;border:1px solid var(--border);text-align:left}
+.report th{background:var(--bg3);font-family:var(--mono);font-size:.78rem;font-weight:600;position:sticky;top:0}
+.report tr:nth-child(even){background:var(--bg2)}
+.report tr:hover{background:var(--bg3)}
 
 /* Trust badges */
 .badge{
-  display:inline-block;font-family:var(--mono);font-size:.65rem;font-weight:700;
-  letter-spacing:.05em;padding:.1rem .4rem;border-radius:3px;
+  display:inline-block;font-family:var(--mono);font-size:.6rem;font-weight:700;
+  letter-spacing:.05em;padding:.1rem .4rem;border-radius:10px;
   vertical-align:middle;margin:0 .15rem;white-space:nowrap;
 }
 .badge-high{background:rgba(34,197,94,.15);color:var(--green);border:1px solid rgba(34,197,94,.3)}
@@ -127,21 +187,19 @@ body{background:var(--bg);color:var(--fg);font-family:var(--serif);line-height:1
 .badge-state{background:rgba(239,68,68,.12);color:var(--red);border:1px solid rgba(239,68,68,.25)}
 
 /* Map popup */
-.marker-popup{font-family:var(--sans);font-size:.8rem;line-height:1.4;max-width:240px}
-.marker-popup .mp-label{font-family:var(--mono);font-size:.65rem;text-transform:uppercase;letter-spacing:.05em;opacity:.6;margin-bottom:2px}
-.marker-popup .mp-headline{font-weight:600;margin-bottom:3px}
-.marker-popup .mp-country{font-size:.7rem;opacity:.5}
-.marker-popup .mp-trust{font-size:.65rem;font-family:var(--mono);font-weight:700;margin-top:3px}
-.marker-popup .mp-trust.t-high{color:var(--green)}
-.marker-popup .mp-trust.t-med{color:var(--yellow)}
-.marker-popup .mp-trust.t-state{color:var(--red)}
+.marker-popup{font-family:var(--sans);font-size:.8rem;line-height:1.4;max-width:260px}
+.marker-popup h4{margin:0 0 4px;font-size:.9rem}
+.marker-popup ul{margin:0;padding-left:1rem}
+.marker-popup li{margin:2px 0;font-size:.75rem}
+.marker-popup .mp-trust{font-family:var(--mono);font-size:.6rem;font-weight:700}
+.popup-trust-high{color:var(--green)}.popup-trust-med{color:var(--yellow)}.popup-trust-state{color:var(--red)}
 
-/* Map marker count badge */
-.map-count{
-  display:inline-block;background:var(--bg4);color:var(--fg2);
-  font-family:var(--mono);font-size:.65rem;padding:.1rem .35rem;
-  border-radius:3px;margin-left:.4rem;
+/* Country highlight in content */
+.country-mention-highlight{
+  background:rgba(59,130,246,.15);border-radius:3px;
+  animation:highlightFade 2s ease forwards;
 }
+@keyframes highlightFade{0%{background:rgba(59,130,246,.3)}100%{background:transparent}}
 
 /* Scrollbar */
 ::-webkit-scrollbar{width:6px}
@@ -150,103 +208,313 @@ body{background:var(--bg);color:var(--fg);font-family:var(--serif);line-height:1
 
 /* Mobile */
 @media(max-width:768px){
-  .sidebar{transform:translateX(-100%)}
-  .sidebar.open{transform:translateX(0)}
-  .main{margin-left:0}
+  .toc-col{display:none}
+  .header-top{padding:.5rem .75rem}
+  .tab-bar{padding:0 .75rem}
+  .layout{padding:0 .75rem}
+  .content-col{padding:1rem 0 3rem}
+  .map-panel.open{height:280px}
   .hamburger{display:block}
-  .content{padding:1rem}
-  .overlay{position:fixed;inset:0;background:rgba(0,0,0,.5);z-index:9;display:none}
-  .overlay.show{display:block}
-  .map-panel.open{height:300px}
+  .kbd-hint{display:none}
+}
+
+/* Print */
+@media print{
+  .header,.map-panel,.toc-col,.map-toggle,.log-btn,.tab-bar,.date-picker{display:none!important}
+  body{background:#fff;color:#000;font-size:11pt}
+  .layout{max-width:100%}
+  .report a{color:#000;text-decoration:underline}
+  .report a::after{content:" (" attr(href) ")";font-size:.8em;color:#666}
+  .badge{border:1px solid #ccc;color:#333!important;background:#eee!important}
+  .report blockquote{border-left:2px solid #999;color:#333}
+  .section-body{max-height:none!important}
+  .country-tag{display:none}
+  #progressBar{display:none}
 }
 </style>
 </head>
 <body>
-<div class="overlay" id="overlay" onclick="toggleSidebar()"></div>
-<nav class="sidebar" id="sidebar">
-  <div class="sidebar-header">
-    <h1>Newsroom</h1>
-    Intelligence Reports
+<div id="progressBar"></div>
+<header class="header">
+  <div class="header-top">
+    <span class="logo">Newsroom</span>
+    <select class="date-picker" id="datePicker" onchange="selectDate(this.value)"></select>
+    <div class="header-spacer"></div>
+    <button class="map-toggle" id="mapToggle" onclick="toggleMap()">
+      🗺 MAP<span class="map-count" id="mapCount">0</span>
+      <span class="kbd-hint">[M]</span>
+    </button>
   </div>
-  <div class="date-list" id="dateList"></div>
-</nav>
-<div class="main">
-  <div class="topbar">
-    <button class="hamburger" onclick="toggleSidebar()">☰</button>
-    <span id="topbarDate">Select a date</span>
-    <div class="topbar-spacer"></div>
-    <button class="map-toggle" id="mapToggle" onclick="toggleMap()">🗺 MAP<span class="map-count" id="mapCount">0</span></button>
-  </div>
-  <div class="map-panel" id="mapPanel">
-    <div id="map"></div>
-  </div>
-  <div id="mapPanel"><div id="map"></div></div>
-  <div class="content" id="content">
-    <div class="empty">Select a date from the sidebar to view reports.</div>
-  </div>
+  <div class="tab-bar" id="tabBar"></div>
+</header>
+<div class="map-panel" id="mapPanel">
+  <div id="map"></div>
 </div>
-<script>
-let currentDate = null;
-let map = null;
-let markerLayer = null;
-let mapOpen = false;
+<div class="layout">
+  <div class="content-col" id="content">
+    <div class="empty">Loading reports…</div>
+  </div>
+  <nav class="toc-col" id="tocCol">
+    <div class="toc-title">Contents</div>
+    <div id="tocList"></div>
+  </nav>
+</div>
 
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script>
+// State
+let currentDate = null;
+let currentSlug = null;
+let reports = [];
+let markers = [];
+let map = null, markerLayer = null, mapOpen = false, mapInit = false;
+let coordsCache = null;
+
+const TRUST_COLORS = {high:'#22c55e', med:'#eab308', state:'#ef4444'};
+const TRUST_LABELS = {high:'🟢 HIGH', med:'🟡 MED', state:'🔴 STATE'};
+
+// --- Map ---
 function initMap() {
-  map = L.map('map', {
-    center: [30, 20],
-    zoom: 2,
-    zoomControl: true,
-    attributionControl: false,
-  });
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    maxZoom: 12,
-  }).addTo(map);
+  if (mapInit) return;
+  mapInit = true;
+  map = L.map('map', {center:[30,20], zoom:2, zoomControl:true, attributionControl:false});
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom:12}).addTo(map);
   markerLayer = L.layerGroup().addTo(map);
 }
 
 function toggleMap() {
-  const panel = document.getElementById('mapPanel');
-  const btn = document.getElementById('mapToggle');
   mapOpen = !mapOpen;
-  panel.classList.toggle('open', mapOpen);
-  btn.classList.toggle('active', mapOpen);
-  if (mapOpen && map) {
+  document.getElementById('mapPanel').classList.toggle('open', mapOpen);
+  document.getElementById('mapToggle').classList.toggle('active', mapOpen);
+  if (mapOpen) {
+    initMap();
     setTimeout(() => map.invalidateSize(), 320);
   }
 }
 
-const TRUST_COLORS = { high: '#22c55e', med: '#eab308', state: '#ef4444' };
-const TRUST_LABELS = { high: '🟢 HIGH', med: '🟡 MED', state: '🔴 STATE' };
-
-function plotMarkers(markers) {
-  if (!markerLayer) return;
+function plotMarkers(mkrs) {
+  if (!markerLayer) { initMap(); }
   markerLayer.clearLayers();
-  document.getElementById('mapCount').textContent = markers.length;
-
-  markers.forEach(m => {
+  document.getElementById('mapCount').textContent = mkrs.length;
+  mkrs.forEach(m => {
     const color = TRUST_COLORS[m.trust] || TRUST_COLORS.high;
     const icon = L.divIcon({
-      className: '',
-      html: `<svg width="14" height="14" viewBox="0 0 14 14"><circle cx="7" cy="7" r="6" fill="${color}" fill-opacity="0.7" stroke="${color}" stroke-width="1.5" stroke-opacity="0.9"/><circle cx="7" cy="7" r="2.5" fill="#fff" fill-opacity="0.9"/></svg>`,
-      iconSize: [14, 14],
-      iconAnchor: [7, 7],
-      popupAnchor: [0, -10],
+      className:'',
+      html:`<svg width="16" height="16" viewBox="0 0 16 16"><circle cx="8" cy="8" r="7" fill="${color}" fill-opacity="0.6" stroke="${color}" stroke-width="1.5"/><circle cx="8" cy="8" r="3" fill="#fff" fill-opacity="0.9"/></svg>`,
+      iconSize:[16,16], iconAnchor:[8,8], popupAnchor:[0,-10],
     });
-
-    const popup = `<div class="marker-popup">
-      <div class="mp-label">${esc(m.label)}</div>
-      <div class="mp-headline">${esc(m.headline)}</div>
-      <div class="mp-country">${esc(m.country)}</div>
-      <div class="mp-trust t-${m.trust}">${TRUST_LABELS[m.trust]}</div>
-    </div>`;
-
-    L.marker([m.lat, m.lng], { icon }).bindPopup(popup).addTo(markerLayer);
+    const mk = L.marker([m.lat, m.lng], {icon});
+    // Popup
+    let popup = `<div class="marker-popup"><h4>${esc(m.country)}</h4><p style="font-size:.75rem;color:#888">${esc(m.headline)}</p><div class="mp-trust popup-trust-${m.trust}">${TRUST_LABELS[m.trust]||''}</div></div>`;
+    mk.bindPopup(popup, {maxWidth:280});
+    // Click → scroll to country in article
+    mk.on('click', () => scrollToCountryInArticle(m.countryKey || m.country.toLowerCase()));
+    mk.addTo(markerLayer);
   });
+}
 
-  // Fit bounds if we have markers
-  if (markers.length > 0 && mapOpen) {
-    const bounds = L.latLngBounds(markers.map(m => [m.lat, m.lng]));
-    map.fitBounds(bounds, { padding: [40, 40], maxZoom: 5 });
+function panMapToCountry(countryKey) {
+  if (!coordsCache) return;
+  const c = coordsCache[countryKey];
+  if (!c) return;
+  if (!mapOpen) toggleMap();
+  setTimeout(() => {
+    map.flyTo([c.lat, c.lng], 5, {duration: 0.8});
+    // Flash matching markers
+    markerLayer.eachLayer(layer => {
+      if (Math.abs(layer.getLatLng().lat - c.lat) < 1 && Math.abs(layer.getLatLng().lng - c.lng) < 1) {
+        layer.openPopup();
+      }
+    });
+  }, mapOpen ? 50 : 400);
+}
+
+function scrollToCountryInArticle(countryKey) {
+  const tags = document.querySelectorAll(`.country-tag[data-country="${countryKey}"]`);
+  if (tags.length > 0) {
+    tags[0].scrollIntoView({behavior:'smooth', block:'center'});
+    tags.forEach(t => {
+      t.classList.add('highlighted');
+      setTimeout(() => t.classList.remove('highlighted'), 1500);
+    });
+  }
+}
+
+// --- Data loading ---
+async function loadDates() {
+  const res = await fetch('/api/dates');
+  const dates = await res.json();
+  const picker = document.getElementById('datePicker');
+  picker.innerHTML = '';
+  dates.forEach(d => {
+    const opt = document.createElement('option');
+    opt.value = d; opt.textContent = d;
+    picker.appendChild(opt);
+  });
+  // Load coords
+  fetch('/api/coords').then(r=>r.json()).then(c => coordsCache = c);
+  if (dates.length > 0) selectDate(dates[0]);
+}
+
+async function selectDate(date) {
+  currentDate = date;
+  document.getElementById('datePicker').value = date;
+  const res = await fetch(`/api/reports/${date}`);
+  const data = await res.json();
+  reports = data.reports || [];
+  markers = data.markers || [];
+  plotMarkers(markers);
+  buildTabs();
+  if (reports.length > 0) {
+    selectReport(reports[0].slug);
+  } else {
+    document.getElementById('content').innerHTML = '<div class="empty">No reports for this date.</div>';
+    document.getElementById('tocList').innerHTML = '';
+  }
+}
+
+function buildTabs() {
+  const bar = document.getElementById('tabBar');
+  bar.innerHTML = '';
+  reports.forEach(r => {
+    const btn = document.createElement('button');
+    btn.className = 'tab';
+    btn.textContent = r.label;
+    btn.dataset.slug = r.slug;
+    btn.onclick = () => selectReport(r.slug);
+    bar.appendChild(btn);
+  });
+}
+
+function selectReport(slug) {
+  currentSlug = slug;
+  // Update tabs
+  document.querySelectorAll('.tab').forEach(t => t.classList.toggle('active', t.dataset.slug === slug));
+  const r = reports.find(x => x.slug === slug);
+  if (!r) return;
+
+  // Build content
+  let html = `<div class="report-meta">
+    <span class="read-time">📖 ${r.readTime} min read</span>`;
+  if (r.hasLog) {
+    html += `<a class="log-btn" href="/report/${currentDate}/${slug}/log" target="_blank">📋 How this report was made</a>`;
+  }
+  // Country tags
+  if (r.countries && r.countries.length > 0) {
+    html += '<span style="margin-left:auto">';
+    r.countries.forEach(c => {
+      html += `<span class="country-tag" data-country="${esc(c)}" onclick="panMapToCountry('${esc(c)}')">${esc(c.replace(/-/g,' '))}</span>`;
+    });
+    html += '</span>';
+  }
+  html += `</div><div class="report">${r.html}</div>`;
+
+  const content = document.getElementById('content');
+  content.innerHTML = html;
+  content.scrollTop = 0;
+
+  // Post-process: collapsible sections, TOC, highlight.js
+  processCollapsibleSections();
+  buildTOC();
+  highlightCode();
+  // Filter map markers to this report
+  const reportMarkers = markers.filter(m => m.label === r.label);
+  // If map is open, show all markers but could filter — keeping all for now
+}
+
+function processCollapsibleSections() {
+  const report = document.querySelector('.report');
+  if (!report) return;
+  const h2s = report.querySelectorAll('h2');
+  h2s.forEach((h2, i) => {
+    const id = 'section-' + i;
+    h2.id = id;
+    // Wrap h2 in a clickable header
+    const wrapper = document.createElement('div');
+    wrapper.className = 'section-header';
+    wrapper.innerHTML = `<span class="section-chevron">▼</span>`;
+    h2.parentNode.insertBefore(wrapper, h2);
+    wrapper.appendChild(h2);
+
+    // Collect siblings until next h2 or section-header
+    const body = document.createElement('div');
+    body.className = 'section-body';
+    body.id = 'body-' + i;
+    wrapper.parentNode.insertBefore(body, wrapper.nextSibling);
+    let next = body.nextSibling;
+    while (next && !(next.classList && next.classList.contains('section-header'))) {
+      const move = next;
+      next = next.nextSibling;
+      body.appendChild(move);
+    }
+    body.style.maxHeight = body.scrollHeight + 'px';
+
+    wrapper.onclick = () => {
+      const collapsed = wrapper.classList.toggle('collapsed');
+      body.classList.toggle('collapsed', collapsed);
+      if (!collapsed) body.style.maxHeight = body.scrollHeight + 'px';
+    };
+  });
+}
+
+function buildTOC() {
+  const tocList = document.getElementById('tocList');
+  const h2s = document.querySelectorAll('.report h2');
+  tocList.innerHTML = '';
+  h2s.forEach((h2, i) => {
+    const a = document.createElement('a');
+    a.className = 'toc-link';
+    a.href = '#section-' + i;
+    a.textContent = h2.textContent.replace(/^[\d.]+\s*/, '').substring(0, 50);
+    a.onclick = (e) => {
+      e.preventDefault();
+      h2.scrollIntoView({behavior:'smooth', block:'start'});
+    };
+    tocList.appendChild(a);
+  });
+}
+
+function highlightCode() {
+  document.querySelectorAll('.report pre code').forEach(block => {
+    hljs.highlightElement(block);
+  });
+}
+
+// --- Progress bar ---
+window.addEventListener('scroll', () => {
+  const content = document.querySelector('.content-col');
+  if (!content) return;
+  const rect = content.getBoundingClientRect();
+  const total = content.scrollHeight - window.innerHeight;
+  const scrolled = -rect.top;
+  const pct = Math.min(100, Math.max(0, (scrolled / total) * 100));
+  document.getElementById('progressBar').style.width = pct + '%';
+
+  // Update active TOC link
+  const h2s = document.querySelectorAll('.report h2');
+  const links = document.querySelectorAll('.toc-link');
+  let activeIdx = 0;
+  h2s.forEach((h2, i) => {
+    if (h2.getBoundingClientRect().top < 150) activeIdx = i;
+  });
+  links.forEach((l, i) => l.classList.toggle('active', i === activeIdx));
+});
+
+// --- Keyboard shortcuts ---
+document.addEventListener('keydown', (e) => {
+  if (e.target.tagName === 'INPUT' || e.target.tagName === 'SELECT' || e.target.tagName === 'TEXTAREA') return;
+  if (e.key === 'm' || e.key === 'M') { toggleMap(); e.preventDefault(); }
+  if (e.key === 'ArrowLeft') { navigateReport(-1); e.preventDefault(); }
+  if (e.key === 'ArrowRight') { navigateReport(1); e.preventDefault(); }
+});
+
+function navigateReport(dir) {
+  if (!reports.length) return;
+  const idx = reports.findIndex(r => r.slug === currentSlug);
+  const next = idx + dir;
+  if (next >= 0 && next < reports.length) {
+    selectReport(reports[next].slug);
   }
 }
 
@@ -256,124 +524,13 @@ function esc(s) {
   return d.innerHTML;
 }
 
-async function loadDates() {
-  const res = await fetch('/api/dates');
-  const dates = await res.json();
-  const list = document.getElementById('dateList');
-  list.innerHTML = '';
-  dates.forEach(d => {
-    const btn = document.createElement('button');
-    btn.className = 'date-item';
-    btn.textContent = d;
-    btn.onclick = () => selectDate(d);
-    list.appendChild(btn);
-  });
-  if (dates.length > 0) selectDate(dates[0]);
-}
-
-async function selectDate(date) {
-  currentDate = date;
-  document.querySelectorAll('.date-item').forEach(el => {
-    el.classList.toggle('active', el.textContent === date);
-  });
-  document.getElementById('topbarDate').textContent = formatDate(date);
-
-  const res = await fetch(`/api/reports/${date}`);
-  const data = await res.json();
-  const groups = data.groups || [];
-  const markers = data.markers || [];
-  const content = document.getElementById('content');
-
-  plotMarkers(markers);
-
-  if (!groups.length) {
-    content.innerHTML = '<div class="empty">No reports for this date.</div>';
-    return;
-  }
-
-  let html = '';
-  groups.forEach(g => {
-    html += `<div class="category"><div class="category-header">${g.category}</div>`;
-    g.reports.forEach(r => {
-      html += `<div class="report"><div class="report-label">${r.label}</div>${r.html}</div>`;
-    });
-    html += '</div>';
-  });
-  content.innerHTML = html;
-  content.scrollTop = 0;
-
-  document.getElementById('sidebar').classList.remove('open');
-  document.getElementById('overlay').classList.remove('show');
-}
-
 function formatDate(d) {
   const dt = new Date(d + 'T00:00:00');
-  return dt.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
+  return dt.toLocaleDateString('en-US', {weekday:'long', year:'numeric', month:'long', day:'numeric'});
 }
 
-function toggleSidebar() {
-  document.getElementById('sidebar').classList.toggle('open');
-  document.getElementById('overlay').classList.toggle('show');
-}
-
-initMap();
+// Init
 loadDates();
-</script>
-<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-<script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
-<script>
-// === Map ===
-let map = null, mapLoaded = false, clusterGroup = null;
-
-function toggleMap() {
-  const panel = document.getElementById('mapPanel');
-  const btn = document.getElementById('mapToggle');
-  const showing = panel.classList.toggle('show');
-  btn.classList.toggle('active', showing);
-  if (showing && !mapLoaded) initMap();
-  if (showing && map) setTimeout(() => map.invalidateSize(), 100);
-}
-
-function initMap() {
-  mapLoaded = true;
-  map = L.map('map', {zoomControl:true}).setView([30, 20], 2);
-  L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
-    attribution:'©OpenStreetMap ©CARTO', maxZoom:18
-  }).addTo(map);
-  loadMapData();
-}
-
-const TRUST_COLORS = {high:'#22c55e', med:'#eab308', state:'#ef4444'};
-
-function makeIcon(trust) {
-  const c = TRUST_COLORS[trust] || TRUST_COLORS.high;
-  return L.divIcon({
-    className:'',
-    html:`<div style="width:14px;height:14px;border-radius:50%;background:${c};border:2px solid #fff;box-shadow:0 0 4px ${c}"></div>`,
-    iconSize:[14,14], iconAnchor:[7,7]
-  });
-}
-
-async function loadMapData() {
-  const res = await fetch('/api/map-data');
-  const data = await res.json();
-  if (clusterGroup) map.removeLayer(clusterGroup);
-  clusterGroup = L.markerClusterGroup({maxClusterRadius:40});
-  data.forEach(d => {
-    const trustLabels = {high:'🟢 HIGH', med:'🟡 MED', state:'🔴 STATE'};
-    const trustClasses = {high:'popup-trust-high', med:'popup-trust-med', state:'popup-trust-state'};
-    let popup = `<h4>${d.country}</h4><ul>`;
-    d.headlines.forEach(h => {
-      const tc = trustClasses[h.trust]||'popup-trust-high';
-      const tl = trustLabels[h.trust]||'🟢 HIGH';
-      popup += `<li><span class="popup-trust ${tc}">${tl}</span> ${h.title} <em style="color:#888">(${h.section})</em></li>`;
-    });
-    popup += '</ul>';
-    const marker = L.marker([d.lat, d.lng], {icon: makeIcon(d.trust)}).bindPopup(popup, {maxWidth:300});
-    clusterGroup.addLayer(marker);
-  });
-  map.addLayer(clusterGroup);
-}
 </script>
 </body>
 </html>

--- a/templates/log.html
+++ b/templates/log.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Editorial Log — {{ label }} — {{ date }}</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg:#0a0c0e;--bg2:#12141a;--bg3:#1a1e24;
+  --fg:#b0b8c0;--fg2:#888e96;--fg3:#5a6068;
+  --accent:#3b82f6;--green:#22c55e;--yellow:#eab308;--red:#ef4444;
+  --border:#222830;
+  --mono:'SF Mono','Cascadia Code','Consolas',monospace;
+}
+html{font-size:15px}
+body{background:var(--bg);color:var(--fg);font-family:var(--mono);line-height:1.65;padding:2rem;max-width:56rem;margin:0 auto}
+a{color:var(--accent);text-decoration:underline;text-underline-offset:2px;word-break:break-all}
+a:hover{color:#93c5fd}
+
+.back{display:inline-block;margin-bottom:1.5rem;font-size:.8rem;color:var(--fg3);text-decoration:none;border:1px solid var(--border);padding:.3rem .6rem;border-radius:3px}
+.back:hover{color:var(--fg);border-color:var(--fg3)}
+
+h1{font-size:1.1rem;color:var(--fg);margin-bottom:.2rem;font-weight:600}
+.meta{font-size:.75rem;color:var(--fg3);margin-bottom:2rem;padding-bottom:1rem;border-bottom:1px solid var(--border)}
+
+.log-content h1{font-size:1rem;color:var(--fg);margin:2rem 0 .5rem;border-bottom:1px solid var(--border);padding-bottom:.3rem}
+.log-content h2{font-size:.9rem;color:var(--fg);margin:1.5rem 0 .4rem}
+.log-content h3{font-size:.8rem;color:var(--fg2);margin:1rem 0 .3rem}
+.log-content p{margin:.4rem 0;font-size:.85rem}
+.log-content ul,.log-content ol{margin:.4rem 0 .4rem 1.5rem;font-size:.85rem}
+.log-content li{margin:.2rem 0}
+.log-content table{width:100%;border-collapse:collapse;margin:.8rem 0;font-size:.78rem}
+.log-content th,.log-content td{padding:.35rem .5rem;border:1px solid var(--border);text-align:left;vertical-align:top}
+.log-content th{background:var(--bg3);font-weight:600;position:sticky;top:0}
+.log-content tr:nth-child(even){background:var(--bg2)}
+.log-content code{background:var(--bg3);padding:.1em .3em;border-radius:2px;font-size:.85em}
+.log-content pre{background:var(--bg2);border:1px solid var(--border);padding:.6rem;border-radius:3px;overflow-x:auto;margin:.6rem 0}
+.log-content pre code{background:none;padding:0}
+.log-content blockquote{border-left:2px solid var(--fg3);padding:.3rem .8rem;margin:.6rem 0;color:var(--fg2)}
+
+/* Source diversity chart */
+.diversity-chart{margin:1.5rem 0;padding:1rem;background:var(--bg2);border:1px solid var(--border);border-radius:4px}
+.diversity-title{font-size:.75rem;color:var(--fg3);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.6rem}
+.diversity-bar{display:flex;align-items:center;margin:.3rem 0}
+.diversity-label{width:120px;font-size:.72rem;color:var(--fg2);flex-shrink:0}
+.diversity-track{flex:1;height:14px;background:var(--bg3);border-radius:2px;overflow:hidden}
+.diversity-fill{height:100%;border-radius:2px;transition:width .5s ease}
+.diversity-value{width:30px;text-align:right;font-size:.7rem;color:var(--fg3);margin-left:.4rem}
+
+@media print{
+  body{background:#fff;color:#000}
+  a{color:#000}
+  .back{display:none}
+}
+</style>
+</head>
+<body>
+<a class="back" href="/">← Back to Dashboard</a>
+<h1>📋 Editorial Log — {{ label }}</h1>
+<div class="meta">{{ date }} · This document shows how the report was sourced, verified, and assembled.</div>
+
+{% if diversity %}
+<div class="diversity-chart">
+  <div class="diversity-title">Source Diversity</div>
+  {% for source, count in diversity.items() %}
+  <div class="diversity-bar">
+    <span class="diversity-label">{{ source }}</span>
+    <div class="diversity-track">
+      <div class="diversity-fill" style="width:{{ (count / diversity.values()|max * 100)|round }}%;background:{% if loop.index % 3 == 1 %}var(--green){% elif loop.index % 3 == 2 %}var(--accent){% else %}var(--yellow){% endif %}"></div>
+    </div>
+    <span class="diversity-value">{{ count }}</span>
+  </div>
+  {% endfor %}
+</div>
+{% endif %}
+
+<div class="log-content">{{ html|safe }}</div>
+</body>
+</html>


### PR DESCRIPTION
Major readability and interactivity improvements

## Changes
- **Map ↔ Article hot-linking**: Click country markers to scroll to mentions; click country tags to pan map
- **Collapsible sections**: H2 headings become expandable/collapsible dropdowns
- **Table of contents**: Sticky TOC on right side, auto-generated from headings
- **Reading progress bar** + estimated read time per report
- **Editorial log page**: New route /report/date/slug/log for companion -log.md files
- **Tab navigation**: Report selector as pills at top with keyboard shortcuts (←→, M)
- **Visual polish**: Trust badges as pills, styled blockquotes, alternating table rows, print CSS
- **Inline links**: Markdown links render as proper styled hyperlinks